### PR TITLE
feat(routes): allow multitenancy through different labels

### DIFF
--- a/injectproxy/alerts_test.go
+++ b/injectproxy/alerts_test.go
@@ -91,7 +91,7 @@ func TestGetAlerts(t *testing.T) {
 			m := newMockUpstream(checkQueryHandler("", tc.queryParam, tc.expQueryValues...))
 			defer m.Close()
 
-			r, err := NewRoutes(m.url, proxyLabel, HTTPFormEnforcer{ParameterName: proxyLabel})
+			r, err := NewRoutes(m.url, HTTPFormEnforcer{ParameterName: proxyLabel, LabelName: proxyLabel})
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}

--- a/injectproxy/routes.go
+++ b/injectproxy/routes.go
@@ -447,6 +447,8 @@ func MustLabelValue(ctx context.Context) string {
 	return v[0]
 }
 
+// MustLabelName returns the label name previously stored using WithLabelName()
+// If there was no label name stored, it will panic.
 func MustLabelName(ctx context.Context) string {
 	label, ok := ctx.Value(keyLabelName).(string)
 	if !ok {
@@ -459,6 +461,7 @@ func MustLabelName(ctx context.Context) string {
 	return label
 }
 
+// MustLabelForceRegex returns the label force regex previously stored using WithForceRegexp()
 func MustLabelForceRegex(ctx context.Context) bool {
 	forceRegex, ok := ctx.Value(keyLabelForceRegex).(bool)
 	if !ok {

--- a/injectproxy/routes_test.go
+++ b/injectproxy/routes_test.go
@@ -162,57 +162,57 @@ func TestWithPassthroughPaths(t *testing.T) {
 
 	t.Run("invalid passthrough options", func(t *testing.T) {
 		// Duplicated /api.
-		_, err := NewRoutes(m.url, proxyLabel, HTTPFormEnforcer{ParameterName: proxyLabel}, WithPassthroughPaths([]string{"/api1", "/api2/something", "/api1"}))
+		_, err := NewRoutes(m.url, HTTPFormEnforcer{ParameterName: proxyLabel, LabelName: proxyLabel}, WithPassthroughPaths([]string{"/api1", "/api2/something", "/api1"}))
 		if err == nil {
 			t.Fatal("expected error")
 		}
 		// Wrong format, params in path.
-		_, err = NewRoutes(m.url, proxyLabel, HTTPFormEnforcer{ParameterName: proxyLabel}, WithPassthroughPaths([]string{"/api1?args=1", "/api1"}))
+		_, err = NewRoutes(m.url, HTTPFormEnforcer{ParameterName: proxyLabel, LabelName: proxyLabel}, WithPassthroughPaths([]string{"/api1?args=1", "/api1"}))
 		if err == nil {
 			t.Fatal("expected error")
 		}
 		// / is not allowed.
-		_, err = NewRoutes(m.url, proxyLabel, HTTPFormEnforcer{ParameterName: proxyLabel}, WithPassthroughPaths([]string{"/", "/api2/something", "/api1"}))
+		_, err = NewRoutes(m.url, HTTPFormEnforcer{ParameterName: proxyLabel, LabelName: proxyLabel}, WithPassthroughPaths([]string{"/", "/api2/something", "/api1"}))
 		if err == nil {
 			t.Fatal("expected error")
 		}
 		// "" is not allowed.
-		_, err = NewRoutes(m.url, proxyLabel, HTTPFormEnforcer{ParameterName: proxyLabel}, WithPassthroughPaths([]string{"/api1", "/api2/something", "", "/api3"}))
+		_, err = NewRoutes(m.url, HTTPFormEnforcer{ParameterName: proxyLabel, LabelName: proxyLabel}, WithPassthroughPaths([]string{"/api1", "/api2/something", "", "/api3"}))
 		if err == nil {
 			t.Fatal("expected error")
 		}
 		// Duplication with existing enforced path is not allowed.
-		_, err = NewRoutes(m.url, proxyLabel, HTTPFormEnforcer{ParameterName: proxyLabel}, WithPassthroughPaths([]string{"/api1", "/api2/something", "/federate", "/api3"}))
+		_, err = NewRoutes(m.url, HTTPFormEnforcer{ParameterName: proxyLabel, LabelName: proxyLabel}, WithPassthroughPaths([]string{"/api1", "/api2/something", "/federate", "/api3"}))
 		if err == nil {
 			t.Fatal("expected error")
 		}
 		// Duplication with existing enforced path is not allowed.
-		_, err = NewRoutes(m.url, proxyLabel, HTTPFormEnforcer{ParameterName: proxyLabel}, WithPassthroughPaths([]string{"/api1", "/api2/something", "/federate/", "/api3"}))
+		_, err = NewRoutes(m.url, HTTPFormEnforcer{ParameterName: proxyLabel, LabelName: proxyLabel}, WithPassthroughPaths([]string{"/api1", "/api2/something", "/federate/", "/api3"}))
 		if err == nil {
 			t.Fatal("expected error")
 		}
 		// Duplication with existing enforced path is not allowed.
-		_, err = NewRoutes(m.url, proxyLabel, HTTPFormEnforcer{ParameterName: proxyLabel}, WithPassthroughPaths([]string{"/api1", "/api2/something", "/federate/some", "/api3"}))
+		_, err = NewRoutes(m.url, HTTPFormEnforcer{ParameterName: proxyLabel, LabelName: proxyLabel}, WithPassthroughPaths([]string{"/api1", "/api2/something", "/federate/some", "/api3"}))
 		if err == nil {
 			t.Fatal("expected error")
 		}
 		// api4 is not valid URL path (does not start with /)
-		_, err = NewRoutes(m.url, proxyLabel, HTTPFormEnforcer{ParameterName: proxyLabel}, WithPassthroughPaths([]string{"/api1", "/api2/something", "api4", "/api3"}))
+		_, err = NewRoutes(m.url, HTTPFormEnforcer{ParameterName: proxyLabel, LabelName: proxyLabel}, WithPassthroughPaths([]string{"/api1", "/api2/something", "api4", "/api3"}))
 		if err == nil {
 			t.Fatal("expected error")
 		}
 		// api4/ is not valid URL path (does not start with /)
-		_, err = NewRoutes(m.url, proxyLabel, HTTPFormEnforcer{ParameterName: proxyLabel}, WithPassthroughPaths([]string{"/api1", "/api2/something", "api4/", "/api3"}))
+		_, err = NewRoutes(m.url, HTTPFormEnforcer{ParameterName: proxyLabel, LabelName: proxyLabel}, WithPassthroughPaths([]string{"/api1", "/api2/something", "api4/", "/api3"}))
 		if err == nil {
 			t.Fatal("expected error")
 		}
 		// api4/something is not valid URL path (does not start with /)
-		_, err = NewRoutes(m.url, proxyLabel, HTTPFormEnforcer{ParameterName: proxyLabel}, WithPassthroughPaths([]string{"/api1", "/api2/something", "api4/something", "/api3"}))
+		_, err = NewRoutes(m.url, HTTPFormEnforcer{ParameterName: proxyLabel, LabelName: proxyLabel}, WithPassthroughPaths([]string{"/api1", "/api2/something", "api4/something", "/api3"}))
 		if err == nil {
 			t.Fatal("expected error")
 		}
 	})
-	r, err := NewRoutes(m.url, proxyLabel, HTTPFormEnforcer{ParameterName: proxyLabel}, WithPassthroughPaths([]string{"/api1", "/api2/something", "/graph/"}))
+	r, err := NewRoutes(m.url, HTTPFormEnforcer{ParameterName: proxyLabel, LabelName: proxyLabel}, WithPassthroughPaths([]string{"/api1", "/api2/something", "/graph/"}))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -351,7 +351,7 @@ func TestMatch(t *testing.T) {
 				)
 				defer m.Close()
 
-				r, err := NewRoutes(m.url, proxyLabel, HTTPFormEnforcer{ParameterName: proxyLabel}, WithEnabledLabelsAPI())
+				r, err := NewRoutes(m.url, HTTPFormEnforcer{ParameterName: proxyLabel, LabelName: proxyLabel}, WithEnabledLabelsAPI())
 				if err != nil {
 					t.Fatalf("unexpected error: %v", err)
 				}
@@ -482,7 +482,7 @@ func TestMatchWithPost(t *testing.T) {
 					),
 				)
 				defer m.Close()
-				r, err := NewRoutes(m.url, proxyLabel, HTTPFormEnforcer{ParameterName: proxyLabel}, WithEnabledLabelsAPI())
+				r, err := NewRoutes(m.url, HTTPFormEnforcer{ParameterName: proxyLabel, LabelName: proxyLabel}, WithEnabledLabelsAPI())
 				if err != nil {
 					t.Fatalf("unexpected error: %v", err)
 				}
@@ -608,7 +608,7 @@ func TestSeries(t *testing.T) {
 				)
 				defer m.Close()
 
-				r, err := NewRoutes(m.url, proxyLabel, HTTPFormEnforcer{ParameterName: proxyLabel})
+				r, err := NewRoutes(m.url, HTTPFormEnforcer{ParameterName: proxyLabel, LabelName: proxyLabel})
 				if err != nil {
 					t.Fatalf("unexpected error: %v", err)
 				}
@@ -747,7 +747,7 @@ func TestSeriesWithPost(t *testing.T) {
 				)
 				defer m.Close()
 
-				r, err := NewRoutes(m.url, proxyLabel, HTTPFormEnforcer{ParameterName: proxyLabel})
+				r, err := NewRoutes(m.url, HTTPFormEnforcer{ParameterName: proxyLabel, LabelName: proxyLabel})
 				if err != nil {
 					t.Fatalf("unexpected error: %v", err)
 				}
@@ -1201,16 +1201,16 @@ func TestQuery(t *testing.T) {
 
 				var labelEnforcer ExtractLabeler
 				if len(tc.staticLabelVal) > 0 {
-					labelEnforcer = StaticLabelEnforcer(tc.staticLabelVal)
+					labelEnforcer = StaticLabelEnforcer{Values: tc.staticLabelVal, LabelName: proxyLabel}
 				} else if tc.headerName != "" {
-					labelEnforcer = HTTPHeaderEnforcer{Name: tc.headerName}
+					labelEnforcer = HTTPHeaderEnforcer{Name: tc.headerName, LabelName: proxyLabel}
 				} else if tc.queryParam != "" {
-					labelEnforcer = HTTPFormEnforcer{ParameterName: tc.queryParam}
+					labelEnforcer = HTTPFormEnforcer{ParameterName: tc.queryParam, LabelName: proxyLabel}
 				} else {
-					labelEnforcer = HTTPFormEnforcer{ParameterName: proxyLabel}
+					labelEnforcer = HTTPFormEnforcer{ParameterName: proxyLabel, LabelName: proxyLabel}
 				}
 
-				r, err := NewRoutes(m.url, proxyLabel, labelEnforcer, opts...)
+				r, err := NewRoutes(m.url, labelEnforcer, opts...)
 				if err != nil {
 					t.Fatalf("unexpected error: %v", err)
 				}

--- a/injectproxy/rules_test.go
+++ b/injectproxy/rules_test.go
@@ -883,7 +883,7 @@ func TestRules(t *testing.T) {
 		t.Run(fmt.Sprintf("%s=%s", proxyLabel, tc.labelv), func(t *testing.T) {
 			m := newMockUpstream(tc.upstream)
 			defer m.Close()
-			r, err := NewRoutes(m.url, proxyLabel, HTTPFormEnforcer{ParameterName: proxyLabel})
+			r, err := NewRoutes(m.url, HTTPFormEnforcer{ParameterName: proxyLabel, LabelName: proxyLabel})
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -1121,7 +1121,7 @@ func TestAlerts(t *testing.T) {
 		t.Run(fmt.Sprintf("%s=%s", proxyLabel, tc.labelv), func(t *testing.T) {
 			m := newMockUpstream(tc.upstream)
 			defer m.Close()
-			r, err := NewRoutes(m.url, proxyLabel, HTTPFormEnforcer{ParameterName: proxyLabel})
+			r, err := NewRoutes(m.url, HTTPFormEnforcer{ParameterName: proxyLabel, LabelName: proxyLabel})
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}

--- a/injectproxy/silences_test.go
+++ b/injectproxy/silences_test.go
@@ -90,7 +90,7 @@ func TestListSilences(t *testing.T) {
 			if tc.regexMatch {
 				opts = append(opts, WithRegexMatch())
 			}
-			r, err := NewRoutes(m.url, proxyLabel, HTTPFormEnforcer{ParameterName: proxyLabel}, opts...)
+			r, err := NewRoutes(m.url, HTTPFormEnforcer{ParameterName: proxyLabel, LabelName: proxyLabel}, opts...)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -335,7 +335,7 @@ func TestDeleteSilence(t *testing.T) {
 			if tc.regexMatch {
 				opts = append(opts, WithRegexMatch())
 			}
-			r, err := NewRoutes(m.url, proxyLabel, HTTPFormEnforcer{ParameterName: proxyLabel}, opts...)
+			r, err := NewRoutes(m.url, HTTPFormEnforcer{ParameterName: proxyLabel, LabelName: proxyLabel}, opts...)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -537,7 +537,7 @@ func TestUpdateSilence(t *testing.T) {
 		t.Run("", func(t *testing.T) {
 			m := newMockUpstream(tc.upstream)
 			defer m.Close()
-			r, err := NewRoutes(m.url, proxyLabel, HTTPFormEnforcer{ParameterName: proxyLabel})
+			r, err := NewRoutes(m.url, HTTPFormEnforcer{ParameterName: proxyLabel, LabelName: proxyLabel})
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -619,7 +619,7 @@ func TestGetAlertGroups(t *testing.T) {
 		t.Run(strings.Join(tc.filters, "&"), func(t *testing.T) {
 			m := newMockUpstream(checkQueryHandler("", tc.queryParam, tc.expQueryValues...))
 			defer m.Close()
-			r, err := NewRoutes(m.url, proxyLabel, HTTPFormEnforcer{ParameterName: proxyLabel})
+			r, err := NewRoutes(m.url, HTTPFormEnforcer{ParameterName: proxyLabel, LabelName: proxyLabel})
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}

--- a/main.go
+++ b/main.go
@@ -150,7 +150,7 @@ func main() {
 	var extractLabeler injectproxy.ExtractLabeler
 	switch {
 	case len(labelValues) > 0:
-		extractLabeler = injectproxy.StaticLabelEnforcer(labelValues)
+		extractLabeler = injectproxy.StaticLabelEnforcer{Values: labelValues, LabelName: label}
 	case queryParam != "":
 		extractLabeler = injectproxy.HTTPFormEnforcer{ParameterName: queryParam}
 	case headerName != "":
@@ -161,7 +161,7 @@ func main() {
 
 	{
 		// Run the insecure HTTP server.
-		routes, err := injectproxy.NewRoutes(upstreamURL, label, extractLabeler, opts...)
+		routes, err := injectproxy.NewRoutes(upstreamURL, extractLabeler, opts...)
 		if err != nil {
 			log.Fatalf("Failed to create injectproxy Routes: %v", err)
 		}


### PR DESCRIPTION
In a larger system, maintaining consistent tenant identifiers across all metrics isn't always practical. For example, some metrics might use `tenant_id` while others rely on `page_id`, depending on the reporting service. Therefore, the proxy needs to decide which label to enforce for each metric.

Instead of using the label parameter in the `NewRoutes` function, we inject the label name in the same way as the label values. As a result, the `ExtractLabeler` handles determining which label name to enforce.

