### PR TITLE
feat(paths): allow path prefixing so it can be hosted on a dynamic subpath

### DIFF
--- a/injectproxy/alerts_test.go
+++ b/injectproxy/alerts_test.go
@@ -91,7 +91,7 @@ func TestGetAlerts(t *testing.T) {
 			m := newMockUpstream(checkQueryHandler("", tc.queryParam, tc.expQueryValues...))
 			defer m.Close()
 
-			r, err := NewRoutes(m.url, HTTPFormEnforcer{ParameterName: proxyLabel, LabelName: proxyLabel})
+			r, err := NewRoutes(m.url, HTTPFormEnforcer{ParameterName: proxyLabel, LabelName: proxyLabel}, WithEnabledAlertsAPI())
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}

--- a/injectproxy/routes.go
+++ b/injectproxy/routes.go
@@ -50,10 +50,12 @@ type routes struct {
 
 type options struct {
 	enableLabelAPIs    bool
+	enableAlertsAPI    bool
 	passthroughPaths   []string
 	errorOnReplace     bool
 	registerer         prometheus.Registerer
 	regexMatch         bool
+	pathPrefix         string
 	modifyProxyRequest func(*http.Request)
 }
 
@@ -71,6 +73,13 @@ func (f optionFunc) apply(o *options) {
 func WithPrometheusRegistry(reg prometheus.Registerer) Option {
 	return optionFunc(func(o *options) {
 		o.registerer = reg
+	})
+}
+
+// WithEnabledAlertsAPI enables proxying to Alerts API. If false, "501 Not implemented" will be return for those.
+func WithEnabledAlertsAPI() Option {
+	return optionFunc(func(o *options) {
+		o.enableAlertsAPI = true
 	})
 }
 
@@ -102,6 +111,12 @@ func WithErrorOnReplace() Option {
 func WithRegexMatch() Option {
 	return optionFunc(func(o *options) {
 		o.regexMatch = true
+	})
+}
+
+func WithPathPrefix(pathPrefix string) Option {
+	return optionFunc(func(o *options) {
+		o.pathPrefix = pathPrefix
 	})
 }
 
@@ -299,6 +314,11 @@ func NewRoutes(upstream *url.URL, extractLabeler ExtractLabeler, opts ...Option)
 		originalDirector := proxy.Director
 		proxy.Director = func(r *http.Request) {
 			opt.modifyProxyRequest(r)
+			if opt.pathPrefix != "" {
+				// compatibility with go1.22 removing the prefix from the path
+				reg := regexp.MustCompile(strings.Replace(opt.pathPrefix, "{customer_id}", "([a-zA-Z0-9_-]+)", -1))
+				r.URL.Path = reg.ReplaceAllString(r.URL.Path, "")
+			}
 			originalDirector(r)
 		}
 	}
@@ -313,46 +333,48 @@ func NewRoutes(upstream *url.URL, extractLabeler ExtractLabeler, opts ...Option)
 	mux := newStrictMux(newInstrumentedMux(http.NewServeMux(), opt.registerer))
 
 	errs := merrors.New(
-		mux.Handle("/federate", r.el.ExtractLabel(enforceMethods(r.matcher, "GET"))),
-		mux.Handle("/api/v1/query", r.el.ExtractLabel(enforceMethods(r.query, "GET", "POST"))),
-		mux.Handle("/api/v1/query_range", r.el.ExtractLabel(enforceMethods(r.query, "GET", "POST"))),
-		mux.Handle("/api/v1/alerts", r.el.ExtractLabel(enforceMethods(r.passthrough, "GET"))),
-		mux.Handle("/api/v1/rules", r.el.ExtractLabel(enforceMethods(r.passthrough, "GET"))),
-		mux.Handle("/api/v1/series", r.el.ExtractLabel(enforceMethods(r.matcher, "GET", "POST"))),
-		mux.Handle("/api/v1/query_exemplars", r.el.ExtractLabel(enforceMethods(r.query, "GET", "POST"))),
+		mux.Handle(opt.pathPrefix+"/federate", r.el.ExtractLabel(enforceMethods(r.matcher, "GET"))),
+		mux.Handle(opt.pathPrefix+"/api/v1/query", r.el.ExtractLabel(enforceMethods(r.query, "GET", "POST"))),
+		mux.Handle(opt.pathPrefix+"/api/v1/query_range", r.el.ExtractLabel(enforceMethods(r.query, "GET", "POST"))),
+		mux.Handle(opt.pathPrefix+"/api/v1/series", r.el.ExtractLabel(enforceMethods(r.matcher, "GET", "POST"))),
+		mux.Handle(opt.pathPrefix+"/api/v1/query_exemplars", r.el.ExtractLabel(enforceMethods(r.query, "GET", "POST"))),
 	)
 
 	if opt.enableLabelAPIs {
 		errs.Add(
-			mux.Handle("/api/v1/labels", r.el.ExtractLabel(enforceMethods(r.matcher, "GET", "POST"))),
+			mux.Handle(opt.pathPrefix+"/api/v1/labels", r.el.ExtractLabel(enforceMethods(r.matcher, "GET", "POST"))),
 			// Full path is /api/v1/label/<label_name>/values but http mux does not support patterns.
 			// This is fine though as we don't care about name for matcher injector.
-			mux.Handle("/api/v1/label/", r.el.ExtractLabel(enforceMethods(r.matcher, "GET"))),
+			mux.Handle(opt.pathPrefix+"/api/v1/label/", r.el.ExtractLabel(enforceMethods(r.matcher, "GET"))),
 		)
 	}
 
-	errs.Add(
-		// Reject multi label values with assertSingleLabelValue() because the
-		// semantics of the Silences API don't support multi-label matchers.
-		mux.Handle("/api/v2/silences", r.el.ExtractLabel(
-			r.errorIfRegexpMatch(
-				enforceMethods(
-					assertSingleLabelValue(r.silences),
-					"GET", "POST",
+	if opt.enableAlertsAPI {
+		errs.Add(
+			mux.Handle(opt.pathPrefix+"/api/v1/alerts", r.el.ExtractLabel(enforceMethods(r.passthrough, "GET"))),
+			mux.Handle(opt.pathPrefix+"/api/v1/rules", r.el.ExtractLabel(enforceMethods(r.passthrough, "GET"))),
+			// Reject multi label values with assertSingleLabelValue() because the
+			// semantics of the Silences API don't support multi-label matchers.
+			mux.Handle(opt.pathPrefix+"/api/v2/silences", r.el.ExtractLabel(
+				r.errorIfRegexpMatch(
+					enforceMethods(
+						assertSingleLabelValue(r.silences),
+						"GET", "POST",
+					),
 				),
-			),
-		)),
-		mux.Handle("/api/v2/silence/", r.el.ExtractLabel(
-			r.errorIfRegexpMatch(
-				enforceMethods(
-					assertSingleLabelValue(r.deleteSilence),
-					"DELETE",
+			)),
+			mux.Handle(opt.pathPrefix+"/api/v2/silence/", r.el.ExtractLabel(
+				r.errorIfRegexpMatch(
+					enforceMethods(
+						assertSingleLabelValue(r.deleteSilence),
+						"DELETE",
+					),
 				),
-			),
-		)),
-		mux.Handle("/api/v2/alerts/groups", r.el.ExtractLabel(enforceMethods(r.enforceFilterParameter, "GET"))),
-		mux.Handle("/api/v2/alerts", r.el.ExtractLabel(enforceMethods(r.alerts, "GET"))),
-	)
+			)),
+			mux.Handle(opt.pathPrefix+"/api/v2/alerts/groups", r.el.ExtractLabel(enforceMethods(r.enforceFilterParameter, "GET"))),
+			mux.Handle(opt.pathPrefix+"/api/v2/alerts", r.el.ExtractLabel(enforceMethods(r.alerts, "GET"))),
+		)
+	}
 
 	errs.Add(
 		mux.Handle("/healthz", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -380,16 +402,19 @@ func NewRoutes(upstream *url.URL, extractLabeler ExtractLabeler, opts ...Option)
 
 	// Register optional passthrough paths.
 	for _, path := range opt.passthroughPaths {
-		if err := mux.Handle(path, http.HandlerFunc(r.passthrough)); err != nil {
+		if err := mux.Handle(opt.pathPrefix+path, http.HandlerFunc(r.passthrough)); err != nil {
 			return nil, err
 		}
 	}
 
 	r.mux = mux
-	r.modifiers = map[string]func(*http.Response) error{
-		"/api/v1/rules":  modifyAPIResponse(r.filterRules),
-		"/api/v1/alerts": modifyAPIResponse(r.filterAlerts),
+	if opt.enableAlertsAPI {
+		r.modifiers = map[string]func(*http.Response) error{
+			opt.pathPrefix + "/api/v1/rules":  modifyAPIResponse(r.filterRules),
+			opt.pathPrefix + "/api/v1/alerts": modifyAPIResponse(r.filterAlerts),
+		}
 	}
+
 	proxy.ModifyResponse = r.ModifyResponse
 	return r, nil
 }

--- a/injectproxy/routes.go
+++ b/injectproxy/routes.go
@@ -298,6 +298,8 @@ func (sle StaticLabelEnforcer) ExtractLabel(next http.HandlerFunc) http.Handler 
 	})
 }
 
+var regexPathParam = regexp.MustCompile("{[a-zA-Z0-9_-]+}")
+
 func NewRoutes(upstream *url.URL, extractLabeler ExtractLabeler, opts ...Option) (*routes, error) {
 	opt := options{}
 	for _, o := range opts {
@@ -316,7 +318,9 @@ func NewRoutes(upstream *url.URL, extractLabeler ExtractLabeler, opts ...Option)
 			opt.modifyProxyRequest(r)
 			if opt.pathPrefix != "" {
 				// compatibility with go1.22 removing the prefix from the path
-				reg := regexp.MustCompile(strings.Replace(opt.pathPrefix, "{customer_id}", "([a-zA-Z0-9_-]+)", -1))
+
+				replacedPathPrefix := regexPathParam.ReplaceAllString(opt.pathPrefix, "([a-zA-Z0-9_-]+)")
+				reg := regexp.MustCompile(replacedPathPrefix)
 				r.URL.Path = reg.ReplaceAllString(r.URL.Path, "")
 			}
 			originalDirector(r)

--- a/injectproxy/routes_test.go
+++ b/injectproxy/routes_test.go
@@ -162,57 +162,57 @@ func TestWithPassthroughPaths(t *testing.T) {
 
 	t.Run("invalid passthrough options", func(t *testing.T) {
 		// Duplicated /api.
-		_, err := NewRoutes(m.url, HTTPFormEnforcer{ParameterName: proxyLabel, LabelName: proxyLabel}, WithPassthroughPaths([]string{"/api1", "/api2/something", "/api1"}))
+		_, err := NewRoutes(m.url, HTTPFormEnforcer{ParameterName: proxyLabel, LabelName: proxyLabel}, WithPassthroughPaths([]string{"/api1", "/api2/something", "/api1"}), WithEnabledAlertsAPI())
 		if err == nil {
 			t.Fatal("expected error")
 		}
 		// Wrong format, params in path.
-		_, err = NewRoutes(m.url, HTTPFormEnforcer{ParameterName: proxyLabel, LabelName: proxyLabel}, WithPassthroughPaths([]string{"/api1?args=1", "/api1"}))
+		_, err = NewRoutes(m.url, HTTPFormEnforcer{ParameterName: proxyLabel, LabelName: proxyLabel}, WithPassthroughPaths([]string{"/api1?args=1", "/api1"}), WithEnabledAlertsAPI())
 		if err == nil {
 			t.Fatal("expected error")
 		}
 		// / is not allowed.
-		_, err = NewRoutes(m.url, HTTPFormEnforcer{ParameterName: proxyLabel, LabelName: proxyLabel}, WithPassthroughPaths([]string{"/", "/api2/something", "/api1"}))
+		_, err = NewRoutes(m.url, HTTPFormEnforcer{ParameterName: proxyLabel, LabelName: proxyLabel}, WithPassthroughPaths([]string{"/", "/api2/something", "/api1"}), WithEnabledAlertsAPI())
 		if err == nil {
 			t.Fatal("expected error")
 		}
 		// "" is not allowed.
-		_, err = NewRoutes(m.url, HTTPFormEnforcer{ParameterName: proxyLabel, LabelName: proxyLabel}, WithPassthroughPaths([]string{"/api1", "/api2/something", "", "/api3"}))
+		_, err = NewRoutes(m.url, HTTPFormEnforcer{ParameterName: proxyLabel, LabelName: proxyLabel}, WithPassthroughPaths([]string{"/api1", "/api2/something", "", "/api3"}), WithEnabledAlertsAPI())
 		if err == nil {
 			t.Fatal("expected error")
 		}
 		// Duplication with existing enforced path is not allowed.
-		_, err = NewRoutes(m.url, HTTPFormEnforcer{ParameterName: proxyLabel, LabelName: proxyLabel}, WithPassthroughPaths([]string{"/api1", "/api2/something", "/federate", "/api3"}))
+		_, err = NewRoutes(m.url, HTTPFormEnforcer{ParameterName: proxyLabel, LabelName: proxyLabel}, WithPassthroughPaths([]string{"/api1", "/api2/something", "/federate", "/api3"}), WithEnabledAlertsAPI())
 		if err == nil {
 			t.Fatal("expected error")
 		}
 		// Duplication with existing enforced path is not allowed.
-		_, err = NewRoutes(m.url, HTTPFormEnforcer{ParameterName: proxyLabel, LabelName: proxyLabel}, WithPassthroughPaths([]string{"/api1", "/api2/something", "/federate/", "/api3"}))
+		_, err = NewRoutes(m.url, HTTPFormEnforcer{ParameterName: proxyLabel, LabelName: proxyLabel}, WithPassthroughPaths([]string{"/api1", "/api2/something", "/federate/", "/api3"}), WithEnabledAlertsAPI())
 		if err == nil {
 			t.Fatal("expected error")
 		}
 		// Duplication with existing enforced path is not allowed.
-		_, err = NewRoutes(m.url, HTTPFormEnforcer{ParameterName: proxyLabel, LabelName: proxyLabel}, WithPassthroughPaths([]string{"/api1", "/api2/something", "/federate/some", "/api3"}))
+		_, err = NewRoutes(m.url, HTTPFormEnforcer{ParameterName: proxyLabel, LabelName: proxyLabel}, WithPassthroughPaths([]string{"/api1", "/api2/something", "/federate/some", "/api3"}), WithEnabledAlertsAPI())
 		if err == nil {
 			t.Fatal("expected error")
 		}
 		// api4 is not valid URL path (does not start with /)
-		_, err = NewRoutes(m.url, HTTPFormEnforcer{ParameterName: proxyLabel, LabelName: proxyLabel}, WithPassthroughPaths([]string{"/api1", "/api2/something", "api4", "/api3"}))
+		_, err = NewRoutes(m.url, HTTPFormEnforcer{ParameterName: proxyLabel, LabelName: proxyLabel}, WithPassthroughPaths([]string{"/api1", "/api2/something", "api4", "/api3"}), WithEnabledAlertsAPI())
 		if err == nil {
 			t.Fatal("expected error")
 		}
 		// api4/ is not valid URL path (does not start with /)
-		_, err = NewRoutes(m.url, HTTPFormEnforcer{ParameterName: proxyLabel, LabelName: proxyLabel}, WithPassthroughPaths([]string{"/api1", "/api2/something", "api4/", "/api3"}))
+		_, err = NewRoutes(m.url, HTTPFormEnforcer{ParameterName: proxyLabel, LabelName: proxyLabel}, WithPassthroughPaths([]string{"/api1", "/api2/something", "api4/", "/api3"}), WithEnabledAlertsAPI())
 		if err == nil {
 			t.Fatal("expected error")
 		}
 		// api4/something is not valid URL path (does not start with /)
-		_, err = NewRoutes(m.url, HTTPFormEnforcer{ParameterName: proxyLabel, LabelName: proxyLabel}, WithPassthroughPaths([]string{"/api1", "/api2/something", "api4/something", "/api3"}))
+		_, err = NewRoutes(m.url, HTTPFormEnforcer{ParameterName: proxyLabel, LabelName: proxyLabel}, WithPassthroughPaths([]string{"/api1", "/api2/something", "api4/something", "/api3"}), WithEnabledAlertsAPI())
 		if err == nil {
 			t.Fatal("expected error")
 		}
 	})
-	r, err := NewRoutes(m.url, HTTPFormEnforcer{ParameterName: proxyLabel, LabelName: proxyLabel}, WithPassthroughPaths([]string{"/api1", "/api2/something", "/graph/"}))
+	r, err := NewRoutes(m.url, HTTPFormEnforcer{ParameterName: proxyLabel, LabelName: proxyLabel}, WithPassthroughPaths([]string{"/api1", "/api2/something", "/graph/"}), WithEnabledAlertsAPI())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/injectproxy/rules_test.go
+++ b/injectproxy/rules_test.go
@@ -883,7 +883,7 @@ func TestRules(t *testing.T) {
 		t.Run(fmt.Sprintf("%s=%s", proxyLabel, tc.labelv), func(t *testing.T) {
 			m := newMockUpstream(tc.upstream)
 			defer m.Close()
-			r, err := NewRoutes(m.url, HTTPFormEnforcer{ParameterName: proxyLabel, LabelName: proxyLabel})
+			r, err := NewRoutes(m.url, HTTPFormEnforcer{ParameterName: proxyLabel, LabelName: proxyLabel}, WithEnabledAlertsAPI())
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -1121,7 +1121,7 @@ func TestAlerts(t *testing.T) {
 		t.Run(fmt.Sprintf("%s=%s", proxyLabel, tc.labelv), func(t *testing.T) {
 			m := newMockUpstream(tc.upstream)
 			defer m.Close()
-			r, err := NewRoutes(m.url, HTTPFormEnforcer{ParameterName: proxyLabel, LabelName: proxyLabel})
+			r, err := NewRoutes(m.url, HTTPFormEnforcer{ParameterName: proxyLabel, LabelName: proxyLabel}, WithEnabledAlertsAPI())
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}

--- a/injectproxy/silences_test.go
+++ b/injectproxy/silences_test.go
@@ -86,7 +86,8 @@ func TestListSilences(t *testing.T) {
 		t.Run(strings.Join(tc.filters, "&"), func(t *testing.T) {
 			m := newMockUpstream(checkQueryHandler("", "filter", tc.expFilters...))
 			defer m.Close()
-			var opts []Option
+			opts := []Option{WithEnabledAlertsAPI()}
+
 			if tc.regexMatch {
 				opts = append(opts, WithRegexMatch())
 			}
@@ -331,7 +332,7 @@ func TestDeleteSilence(t *testing.T) {
 		t.Run("", func(t *testing.T) {
 			m := newMockUpstream(tc.upstream)
 			defer m.Close()
-			var opts []Option
+			opts := []Option{WithEnabledAlertsAPI()}
 			if tc.regexMatch {
 				opts = append(opts, WithRegexMatch())
 			}
@@ -537,7 +538,7 @@ func TestUpdateSilence(t *testing.T) {
 		t.Run("", func(t *testing.T) {
 			m := newMockUpstream(tc.upstream)
 			defer m.Close()
-			r, err := NewRoutes(m.url, HTTPFormEnforcer{ParameterName: proxyLabel, LabelName: proxyLabel})
+			r, err := NewRoutes(m.url, HTTPFormEnforcer{ParameterName: proxyLabel, LabelName: proxyLabel}, WithEnabledAlertsAPI())
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -619,7 +620,7 @@ func TestGetAlertGroups(t *testing.T) {
 		t.Run(strings.Join(tc.filters, "&"), func(t *testing.T) {
 			m := newMockUpstream(checkQueryHandler("", tc.queryParam, tc.expQueryValues...))
 			defer m.Close()
-			r, err := NewRoutes(m.url, HTTPFormEnforcer{ParameterName: proxyLabel, LabelName: proxyLabel})
+			r, err := NewRoutes(m.url, HTTPFormEnforcer{ParameterName: proxyLabel, LabelName: proxyLabel}, WithEnabledAlertsAPI())
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}


### PR DESCRIPTION
So we need to have something like a dynamic path for the tenant we are going for.

So it would be something like `/tenant/{tenant_id/api/v1/labels`.

In order to do that dynamic pathing (coming from go1.22) in this project, we have to prefix it and also remove the prefix accordingly again, when redirecting to the upstream. 